### PR TITLE
fix: fixed `test_numpy_mean` for all backends

### DIFF
--- a/ivy_tests/test_ivy/test_frontends/test_numpy/test_statistics/test_averages_and_variances.py
+++ b/ivy_tests/test_ivy/test_frontends/test_numpy/test_statistics/test_averages_and_variances.py
@@ -222,7 +222,7 @@ def test_numpy_mean(
     on_device,
     keep_dims,
 ):
-    input_dtypes, x, axis = dtype_and_x
+    input_dtypes, x, axis, _, _ = dtype_and_x
     where, input_dtypes, test_flags = np_frontend_helpers.handle_where_and_array_bools(
         where=where,
         input_dtype=input_dtypes,
@@ -239,6 +239,7 @@ def test_numpy_mean(
         axis=axis,
         dtype=dtype[0],
         out=None,
+        atol=0.0005,
         keepdims=keep_dims,
         where=where,
     )


### PR DESCRIPTION
<!--
This template will help you to have a meaningful PR, please follow it and do not leave it blank.
-->

# PR Description

 - fixed the tuple destructuring error in the function.
 - Numpy's mean is not as exact as of other frameworks. It sometimes rounds up the mean while other frameworks don't which causes some mismatch in results. Therefore an `atol` of 0.0005 is added to the test.

<!--
If there is no related issue, please add a short description about your PR.
-->

## Related Issue

<!--
Please use this format to link other issues with their numbers: Close #123
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes #28751
Closes #28752
Closes #28753
Closes #28754

## Checklist

- [ ] Did you add a function?
- [ ] Did you add the tests?
- [x] Did you run your tests and are your tests passing?
- [x] Did pre-commit not fail on any check?
- [x] Did you follow the steps we provided?

<!--
Please mark your PR as a draft if you realise after the fact that your tests are not passing or
that your pre-commit check has some failures.

Here are some relevant resources regarding tests and pre-commit:

https://unify.ai/docs/ivy/overview/deep_dive/ivy_tests.html
https://unify.ai/docs/ivy/overview/deep_dive/formatting.html#pre-commit

-->

### Socials

<!--
If you have Twitter, please provide it here otherwise just ignore this.
-->
